### PR TITLE
Added a method for registering Twig extensions.

### DIFF
--- a/src/Service/TemplateRendererInterface.php
+++ b/src/Service/TemplateRendererInterface.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Noctis\KickStart\Service;
 
+use Twig\Extension\ExtensionInterface;
+
 interface TemplateRendererInterface
 {
     public function render(string $template, array $params = []): string;
 
     public function registerFunction(string $name, callable $function): void;
+
+    public function registerExtension(ExtensionInterface $extension): void;
 }

--- a/src/Service/TwigRenderer.php
+++ b/src/Service/TwigRenderer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Noctis\KickStart\Service;
 
 use Twig\Environment as Twig;
+use Twig\Extension\ExtensionInterface;
 use Twig\TwigFunction;
 
 final class TwigRenderer implements TemplateRendererInterface
@@ -28,5 +29,11 @@ final class TwigRenderer implements TemplateRendererInterface
             ->addFunction(
                 new TwigFunction($name, $function)
             );
+    }
+
+    public function registerExtension(ExtensionInterface $extension): void
+    {
+        $this->twig
+            ->addExtension($extension);
     }
 }


### PR DESCRIPTION
Added a method for registering Twig extensions: `TemplateRendererInterface::registerExtension(ExtensionInterface $extension)`.

See: https://github.com/Noctis/kickstart-app/pull/16