### PR TITLE
`ResponseFactory` breakdown & deprecation

### DIFF
--- a/src/Http/Action/AbstractAction.php
+++ b/src/Http/Action/AbstractAction.php
@@ -17,15 +17,23 @@ use Noctis\KickStart\Http\Response\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriFactoryInterface;
 
+/**
+ * @deprecated since 2.3.0; will be removed in 3.0.0
+ */
 abstract class AbstractAction
 {
     protected ServerRequestInterface $request;
     protected Container $flashContainer;
 
+    /**
+     * @psalm-suppress DeprecatedClass
+     */
     private ResponseFactoryInterface $responseFactory;
+
     private UriFactoryInterface $uriFactory;
     private ConfigurationInterface $configuration;
 
+    /** @psalm-suppress DeprecatedClass */
     public function __construct(
         ResponseFactoryInterface $responseFactory,
         UriFactoryInterface $uriFactory,
@@ -46,6 +54,7 @@ abstract class AbstractAction
     {
         $baseHref = $this->getBaseHref();
 
+        /** @psalm-suppress DeprecatedMethod */
         return $this->responseFactory
             ->htmlResponse($view, $baseHref, $params);
     }
@@ -70,6 +79,7 @@ abstract class AbstractAction
                 );
         }
 
+        /** @psalm-suppress DeprecatedMethod */
         return $this->responseFactory
             ->redirectionResponse($uri, $params);
     }
@@ -88,6 +98,7 @@ abstract class AbstractAction
 
     protected function sendAttachment(AttachmentInterface $attachment): AttachmentResponse
     {
+        /** @psalm-suppress DeprecatedMethod */
         return $this->responseFactory
             ->attachmentResponse($attachment);
     }
@@ -112,6 +123,7 @@ abstract class AbstractAction
 
     protected function notFound(): EmptyResponse
     {
+        /** @psalm-suppress DeprecatedMethod */
         return $this->responseFactory
             ->notFoundResponse();
     }

--- a/src/Http/Factory/BaseHrefFactory.php
+++ b/src/Http/Factory/BaseHrefFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Http\Factory;
+
+use Noctis\KickStart\Configuration\ConfigurationInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class BaseHrefFactory implements BaseHrefFactoryInterface
+{
+    private ConfigurationInterface $configuration;
+
+    public function __construct(ConfigurationInterface $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    public function createFromRequest(ServerRequestInterface $request): string
+    {
+        $uri = $request->getUri();
+
+        $portPart = $uri->getPort() !== null
+            ? ':' . (string)$uri->getPort()
+            : '';
+
+        return sprintf(
+            '%s://%s/',
+            $uri->getScheme(),
+            $uri->getHost() . $portPart . $this->configuration->getBaseHref()
+        );
+    }
+}

--- a/src/Http/Factory/BaseHrefFactoryInterface.php
+++ b/src/Http/Factory/BaseHrefFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Http\Factory;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+interface BaseHrefFactoryInterface
+{
+    public function createFromRequest(ServerRequestInterface $request): string;
+}

--- a/src/Http/Middleware/AbstractMiddleware.php
+++ b/src/Http/Middleware/AbstractMiddleware.php
@@ -12,8 +12,14 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 abstract class AbstractMiddleware implements MiddlewareInterface
 {
+    /**
+     * @psalm-suppress DeprecatedClass
+     */
     protected ResponseFactoryInterface $responseFactory;
 
+    /**
+     * @psalm-suppress DeprecatedClass
+     */
     public function __construct(ResponseFactoryInterface $responseFactory)
     {
         $this->responseFactory = $responseFactory;

--- a/src/Http/Response/Factory/AttachmentResponseFactory.php
+++ b/src/Http/Response/Factory/AttachmentResponseFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Http\Response\Factory;
+
+use Noctis\KickStart\Http\Response\Attachment\AttachmentFactoryInterface;
+use Noctis\KickStart\Http\Response\AttachmentResponse;
+use Noctis\KickStart\Http\Response\Headers\DispositionInterface;
+
+final class AttachmentResponseFactory implements AttachmentResponseFactoryInterface
+{
+    private AttachmentFactoryInterface $attachmentFactory;
+
+    public function __construct(AttachmentFactoryInterface $attachmentFactory)
+    {
+        $this->attachmentFactory = $attachmentFactory;
+    }
+
+    public function sendFile(
+        string $path,
+        string $mimeType,
+        DispositionInterface $disposition
+    ): AttachmentResponse {
+        return new AttachmentResponse(
+            $this->attachmentFactory
+                ->createFromPath($path, $mimeType, $disposition)
+        );
+    }
+
+    public function sendContent(
+        string $content,
+        string $mimeType,
+        DispositionInterface $disposition
+    ): AttachmentResponse {
+        return new AttachmentResponse(
+            $this->attachmentFactory
+                ->createFromContent($content, $mimeType, $disposition)
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function sendResource(
+        $resource,
+        string $mimeType,
+        DispositionInterface $disposition
+    ): AttachmentResponse {
+        return new AttachmentResponse(
+            $this->attachmentFactory
+                ->createFromResource($resource, $mimeType, $disposition)
+        );
+    }
+}

--- a/src/Http/Response/Factory/AttachmentResponseFactoryInterface.php
+++ b/src/Http/Response/Factory/AttachmentResponseFactoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Http\Response\Factory;
+
+use Noctis\KickStart\Http\Response\AttachmentResponse;
+use Noctis\KickStart\Http\Response\Headers\DispositionInterface;
+
+interface AttachmentResponseFactoryInterface
+{
+    public function sendFile(
+        string $path,
+        string $mimeType,
+        DispositionInterface $disposition
+    ): AttachmentResponse;
+
+    public function sendContent(
+        string $content,
+        string $mimeType,
+        DispositionInterface $disposition
+    ): AttachmentResponse;
+
+    /**
+     * @param resource $resource
+     */
+    public function sendResource(
+        $resource,
+        string $mimeType,
+        DispositionInterface $disposition
+    ): AttachmentResponse;
+}

--- a/src/Http/Response/Factory/HtmlResponseFactory.php
+++ b/src/Http/Response/Factory/HtmlResponseFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Http\Response\Factory;
+
+use Laminas\Diactoros\Response\HtmlResponse;
+use Noctis\KickStart\Http\Factory\BaseHrefFactoryInterface;
+use Noctis\KickStart\Service\TemplateRendererInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class HtmlResponseFactory implements HtmlResponseFactoryInterface
+{
+    private TemplateRendererInterface $templateRenderer;
+    private ServerRequestInterface $request;
+    private BaseHrefFactoryInterface $baseHrefFactory;
+
+    public function __construct(
+        BaseHrefFactoryInterface  $baseHrefFactory,
+        ServerRequestInterface    $request,
+        TemplateRendererInterface $templateRenderer
+    ) {
+        $this->templateRenderer = $templateRenderer;
+        $this->request = $request;
+        $this->baseHrefFactory = $baseHrefFactory;
+    }
+
+    public function render(string $view, array $params = []): HtmlResponse
+    {
+        $params['basehref'] = $this->baseHrefFactory
+            ->createFromRequest($this->request);
+
+        return new HtmlResponse(
+            $this->templateRenderer
+                ->render($view, $params)
+        );
+    }
+}

--- a/src/Http/Response/Factory/HtmlResponseFactoryInterface.php
+++ b/src/Http/Response/Factory/HtmlResponseFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Http\Response\Factory;
+
+use Laminas\Diactoros\Response\HtmlResponse;
+
+interface HtmlResponseFactoryInterface
+{
+    public function render(string $view, array $params = []): HtmlResponse;
+}

--- a/src/Http/Response/Factory/NotFoundResponseFactory.php
+++ b/src/Http/Response/Factory/NotFoundResponseFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Http\Response\Factory;
+
+use Fig\Http\Message\StatusCodeInterface;
+use Laminas\Diactoros\Response\EmptyResponse;
+use Laminas\Diactoros\Response\TextResponse;
+
+final class NotFoundResponseFactory implements NotFoundResponseFactoryInterface
+{
+    public function notFound(string $message = null): EmptyResponse | TextResponse
+    {
+        if ($message !== null && $message !== '') {
+            return new TextResponse($message, StatusCodeInterface::STATUS_NOT_FOUND);
+        }
+
+        return new EmptyResponse(StatusCodeInterface::STATUS_NOT_FOUND);
+    }
+}

--- a/src/Http/Response/Factory/NotFoundResponseFactoryInterface.php
+++ b/src/Http/Response/Factory/NotFoundResponseFactoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Http\Response\Factory;
+
+use Laminas\Diactoros\Response\EmptyResponse;
+use Laminas\Diactoros\Response\TextResponse;
+
+interface NotFoundResponseFactoryInterface
+{
+    public function notFound(string $message = null): EmptyResponse | TextResponse;
+}

--- a/src/Http/Response/Factory/RedirectResponseFactory.php
+++ b/src/Http/Response/Factory/RedirectResponseFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Http\Response\Factory;
+
+use Laminas\Diactoros\Response\RedirectResponse;
+use Noctis\KickStart\Configuration\ConfigurationInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriFactoryInterface;
+
+final class RedirectResponseFactory implements RedirectResponseFactoryInterface
+{
+    private UriFactoryInterface $uriFactory;
+    private ServerRequestInterface $request;
+    private ConfigurationInterface $configuration;
+
+    public function __construct(
+        UriFactoryInterface    $uriFactory,
+        ServerRequestInterface $request,
+        ConfigurationInterface $configuration
+    ) {
+        $this->uriFactory = $uriFactory;
+        $this->request = $request;
+        $this->configuration = $configuration;
+    }
+
+    public function toPath(string $path, array $queryParams = []): RedirectResponse
+    {
+        if (preg_match('/:\/\//', $path) === 1) {
+            $uri = $this->uriFactory
+                ->createUri($path);
+        } else {
+            $uri = $this->request
+                ->getUri()
+                ->withPath(
+                    sprintf(
+                        '%s/%s',
+                        $this->configuration
+                            ->getBaseHref(),
+                        $path
+                    )
+                );
+        }
+
+        if (!empty($queryParams)) {
+            $uri = $uri->withQuery(
+                http_build_query($queryParams)
+            );
+        }
+
+        return new RedirectResponse((string)$uri);
+    }
+}

--- a/src/Http/Response/Factory/RedirectResponseFactoryInterface.php
+++ b/src/Http/Response/Factory/RedirectResponseFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Http\Response\Factory;
+
+use Laminas\Diactoros\Response\RedirectResponse;
+
+interface RedirectResponseFactoryInterface
+{
+    public function toPath(string $path, array $queryParams = []): RedirectResponse;
+}

--- a/src/Http/Response/ResponseFactory.php
+++ b/src/Http/Response/ResponseFactory.php
@@ -13,6 +13,10 @@ use Noctis\KickStart\File\FileInterface;
 use Noctis\KickStart\Service\TemplateRendererInterface;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @deprecated since 2.3.0; will be removed in 3.0.0
+ * @psalm-suppress DeprecatedInterface
+ */
 final class ResponseFactory implements ResponseFactoryInterface
 {
     private TemplateRendererInterface $templateRenderer;
@@ -57,11 +61,17 @@ final class ResponseFactory implements ResponseFactoryInterface
         return new FileResponse($file);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function attachmentResponse(AttachmentInterface $attachment): AttachmentResponse
     {
         return new AttachmentResponse($attachment);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function notFoundResponse(): EmptyResponse
     {
         return new EmptyResponse(StatusCodeInterface::STATUS_NOT_FOUND);

--- a/src/Http/Response/ResponseFactoryInterface.php
+++ b/src/Http/Response/ResponseFactoryInterface.php
@@ -11,26 +11,37 @@ use Noctis\KickStart\Http\Response\Attachment\AttachmentInterface;
 use Noctis\KickStart\File\FileInterface;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @deprecated since 2.3.0; will be removed in 3.0.0
+ */
 interface ResponseFactoryInterface
 {
     /**
+     * @deprecated Please use `Factory\HtmlResponseFactoryInterface::render()` method.
      * @param array<string, mixed> $params
      */
     public function htmlResponse(string $view, string $baseHref, array $params = []): HtmlResponse;
 
     /**
+     * @deprecated Please use `Factory\RedirectResponseFactoryInterface::toPath()` method.
      * @param array<string, string> $params
      */
     public function redirectionResponse(UriInterface $uri, array $params = []): RedirectResponse;
 
     /**
      * @deprecated since version 2.1.0 (will be removed in 3.0.0)
-     * @see ResponseFactoryInterface::attachmentResponse()
+     * @see Please use `Factory\AttachmentResponseFactory` methods.
      * @psalm-suppress DeprecatedClass
      */
     public function fileResponse(FileInterface $file): FileResponse;
 
+    /**
+     * @deprecated Please use `Factory\AttachmentResponseFactory` methods.
+     */
     public function attachmentResponse(AttachmentInterface $attachment): AttachmentResponse;
 
+    /**
+     * @deprecated Please use `Factory\NotFoundResponseFactory::notFound()` method.
+     */
     public function notFoundResponse(): EmptyResponse;
 }

--- a/src/Http/Routing/Handler/Definition/RouteHandlerDefinition.php
+++ b/src/Http/Routing/Handler/Definition/RouteHandlerDefinition.php
@@ -9,7 +9,10 @@ use Noctis\KickStart\Http\Middleware\AbstractMiddleware;
 
 final class RouteHandlerDefinition implements RouteHandlerDefinitionInterface
 {
-    /** @var class-string<AbstractAction> */
+    /**
+     * @var class-string<AbstractAction>
+     * @psalm-suppress DeprecatedClass
+     */
     private string $actionClassName;
 
     /** @var list<class-string<AbstractMiddleware>> */
@@ -17,13 +20,17 @@ final class RouteHandlerDefinition implements RouteHandlerDefinitionInterface
 
     /**
      * @param class-string<AbstractAction>|array $value
+     * @psalm-suppress DeprecatedClass
      */
     public static function createFromValue(string | array $value): self
     {
         if (is_string($value)) {
             return new self($value, []);
         } else {
-            /** @var class-string<AbstractAction> $actionClassName */
+            /**
+             * @var class-string<AbstractAction> $actionClassName
+             * @psalm-suppress DeprecatedClass
+             */
             $actionClassName = $value[0];
 
             $guardNames = [];
@@ -39,6 +46,7 @@ final class RouteHandlerDefinition implements RouteHandlerDefinitionInterface
     /**
      * @param class-string<AbstractAction>           $actionClassName
      * @param list<class-string<AbstractMiddleware>> $guardNames
+     * @psalm-suppress DeprecatedClass
      */
     public function __construct(string $actionClassName, array $guardNames)
     {

--- a/src/Http/Routing/Handler/Definition/RouteHandlerDefinitionInterface.php
+++ b/src/Http/Routing/Handler/Definition/RouteHandlerDefinitionInterface.php
@@ -6,16 +6,18 @@ namespace Noctis\KickStart\Http\Routing\Handler\Definition;
 
 use Noctis\KickStart\Http\Action\AbstractAction;
 use Noctis\KickStart\Http\Middleware\AbstractMiddleware;
+use Psr\Http\Server\MiddlewareInterface;
 
 interface RouteHandlerDefinitionInterface
 {
     /**
      * @return class-string<AbstractAction>
+     * @psalm-suppress DeprecatedClass
      */
     public function getActionClassName(): string;
 
     /**
-     * @return list<class-string<AbstractMiddleware>>
+     * @return list<class-string<MiddlewareInterface>>
      */
     public function getGuardNames(): array;
 }

--- a/src/Http/Routing/Handler/FoundHandler.php
+++ b/src/Http/Routing/Handler/FoundHandler.php
@@ -44,6 +44,7 @@ final class FoundHandler implements FoundHandlerInterface
 
     /**
      * @param class-string<AbstractAction> $actionClassName
+     * @psalm-suppress DeprecatedClass
      */
     private function getAction(string $actionClassName): AbstractAction
     {

--- a/src/Http/Routing/RequestHandler.php
+++ b/src/Http/Routing/RequestHandler.php
@@ -14,6 +14,10 @@ use Psr\Http\Message\ServerRequestInterface;
 final class RequestHandler implements RequestHandlerInterface
 {
     private Container $container;
+
+    /**
+     * @psalm-suppress DeprecatedClass
+     */
     private AbstractAction $action;
 
     /** @var list<MiddlewareInterface> */
@@ -21,6 +25,7 @@ final class RequestHandler implements RequestHandlerInterface
 
     /**
      * @param list<MiddlewareInterface> $guards
+     * @psalm-suppress DeprecatedClass
      */
     public function __construct(Container $container, AbstractAction $action, array $guards)
     {

--- a/src/Http/Routing/RoutesLoader.php
+++ b/src/Http/Routing/RoutesLoader.php
@@ -42,6 +42,7 @@ final class RoutesLoader implements RoutesLoaderInterface
          * @var string $method
          * @var string $url
          * @var class-string<AbstractAction> $action
+         * @psalm-suppress DeprecatedClass
          */
         [$method, $url, $action] = $definition;
         if (count($definition) === 4) {
@@ -57,6 +58,7 @@ final class RoutesLoader implements RoutesLoaderInterface
     /**
      * @param class-string<AbstractAction>           $action
      * @param list<class-string<AbstractMiddleware>> $guards
+     * @psalm-suppress DeprecatedClass
      */
     private function addRoute(RouteCollector $r, string $method, string $url, string $action, array $guards): void
     {

--- a/src/Http/Service/FlashMessageService.php
+++ b/src/Http/Service/FlashMessageService.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Http\Service;
+
+use Laminas\Session\Container;
+
+final class FlashMessageService implements FlashMessageServiceInterface
+{
+    private Container $flashContainer;
+
+    public function __construct(Container $flashContainer)
+    {
+        $this->flashContainer = $flashContainer;
+    }
+
+    public function setFlashMessage(string $name, ?string $message): void
+    {
+        $this->flashContainer[$name] = $message;
+    }
+
+    public function setWarningMessage(string $message): void
+    {
+        $this->setFlashMessage('warning', $message);
+    }
+
+    public function getFlashMessage(string $name, bool $persist = false): ?string
+    {
+        /** @var string|null $message */
+        $message = $this->flashContainer[$name] ?? null;
+        unset($this->flashContainer[$name]);
+
+        if ($message !== null && $persist) {
+            $this->setFlashMessage($name, $message);
+        }
+
+        return $message;
+    }
+}

--- a/src/Http/Service/FlashMessageServiceInterface.php
+++ b/src/Http/Service/FlashMessageServiceInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Http\Service;
+
+interface FlashMessageServiceInterface
+{
+    public function setFlashMessage(string $name, ?string $message): void;
+
+    public function setWarningMessage(string $message): void;
+
+    public function getFlashMessage(string $name, bool $persist = false): ?string;
+}

--- a/src/Provider/HttpServicesProvider.php
+++ b/src/Provider/HttpServicesProvider.php
@@ -8,7 +8,17 @@ use Laminas\Diactoros\UriFactory;
 use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Laminas\Session\Container as SessionContainer;
+use Noctis\KickStart\Http\Factory\BaseHrefFactory;
+use Noctis\KickStart\Http\Factory\BaseHrefFactoryInterface;
 use Noctis\KickStart\Http\Factory\RequestFactory;
+use Noctis\KickStart\Http\Response\Factory\AttachmentResponseFactory;
+use Noctis\KickStart\Http\Response\Factory\AttachmentResponseFactoryInterface;
+use Noctis\KickStart\Http\Response\Factory\HtmlResponseFactory;
+use Noctis\KickStart\Http\Response\Factory\HtmlResponseFactoryInterface;
+use Noctis\KickStart\Http\Response\Factory\NotFoundResponseFactory;
+use Noctis\KickStart\Http\Response\Factory\NotFoundResponseFactoryInterface;
+use Noctis\KickStart\Http\Response\Factory\RedirectResponseFactory;
+use Noctis\KickStart\Http\Response\Factory\RedirectResponseFactoryInterface;
 use Noctis\KickStart\Http\Response\ResponseFactory;
 use Noctis\KickStart\Http\Response\ResponseFactoryInterface;
 use Noctis\KickStart\Http\Routing\Handler\FoundHandler;
@@ -21,6 +31,8 @@ use Noctis\KickStart\Http\Routing\HttpInfoProvider;
 use Noctis\KickStart\Http\Routing\HttpInfoProviderInterface;
 use Noctis\KickStart\Http\Routing\RoutesLoader;
 use Noctis\KickStart\Http\Routing\RoutesLoaderInterface;
+use Noctis\KickStart\Http\Service\FlashMessageService;
+use Noctis\KickStart\Http\Service\FlashMessageServiceInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriFactoryInterface;
 
@@ -34,12 +46,19 @@ final class HttpServicesProvider implements ServicesProviderInterface
      */
     public function getServicesDefinitions(): array
     {
+        /** @psalm-suppress DeprecatedClass */
         return [
+            AttachmentResponseFactoryInterface::class => AttachmentResponseFactory::class,
+            BaseHrefFactoryInterface::class => BaseHrefFactory::class,
             EmitterInterface::class => SapiEmitter::class,
+            FlashMessageServiceInterface::class => FlashMessageService::class,
             FoundHandlerInterface::class => FoundHandler::class,
+            HtmlResponseFactoryInterface::class => HtmlResponseFactory::class,
             HttpInfoProviderInterface::class => HttpInfoProvider::class,
             MethodNotAllowedHandlerInterface::class => MethodNotAllowedHandler::class,
             NotFoundHandlerInterface::class => NotFoundHandler::class,
+            NotFoundResponseFactoryInterface::class => NotFoundResponseFactory::class,
+            RedirectResponseFactoryInterface::class => RedirectResponseFactory::class,
             ResponseFactoryInterface::class => ResponseFactory::class,
             RoutesLoaderInterface::class => RoutesLoader::class,
             ServerRequestInterface::class => factory([RequestFactory::class, 'createFromGlobals']),


### PR DESCRIPTION
* `ResponseFactory` has been broken down into separate, smaller factories,
* `ResponseFactoryInterface` and `ResponseFactory` are now marked as deprecated (to be removed in `3.0.0`).
* `AbstractAction` is now marked as deprecated (to be removed in `3.0.0`).
* Added a new class for managing flash messages: `Noctis\KickStart\Http\Service\FlashMessageService` (replaces `AbstractAction::setFlashMessage()` and `AbstractAction::getFlashMessage()` methods).