### PR TITLE
Renamed debugging option in `.env`

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -8,7 +8,7 @@ final class Configuration implements ConfigurationInterface
 {
     public static function isProduction(): bool
     {
-        return self::get('debug') === false;
+        return self::get('APP_ENV') === 'prod';
     }
 
     public static function getBaseHref(): string

--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -31,9 +31,11 @@ final class TwigServiceProvider implements ServicesProviderInterface
                     'strict_variables' => $debugMode,
                 ]);
 
-                $twig->addExtension(
-                    new DebugExtension()
-                );
+                if ($debugMode) {
+                    $twig->addExtension(
+                        new DebugExtension()
+                    );
+                }
 
                 return $twig;
             }


### PR DESCRIPTION
Renamed `debug=true|false` (in `.env`) to `APP_DEV=prod|dev`.

See: https://github.com/Noctis/kickstart-app/pull/22