### PR TITLE
Bugfix: Trying to Debug in Twig Template While in Prod. Environment Crashes the App

### DIFF
--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -30,12 +30,9 @@ final class TwigServiceProvider implements ServicesProviderInterface
                     'debug'            => $debugMode,
                     'strict_variables' => $debugMode,
                 ]);
-
-                if ($debugMode) {
-                    $twig->addExtension(
-                        new DebugExtension()
-                    );
-                }
+                $twig->addExtension(
+                    new DebugExtension()
+                );
 
                 return $twig;
             }


### PR DESCRIPTION
Using the `dump()` function in Twig template while the app. is running in production environment results in a crash (500).

See: https://github.com/Noctis/kickstart-app/pull/69