### PR TITLE
Code Imrovement in `BootableApplicationTrait`

### DIFF
--- a/src/BootableApplicationTrait.php
+++ b/src/BootableApplicationTrait.php
@@ -9,7 +9,6 @@ use Noctis\KickStart\Service\Container\PhpDi\ContainerBuilder;
 use Psr\Container\ContainerInterface;
 
 use function Psl\Vec\concat;
-use function Psl\Vec\map;
 
 trait BootableApplicationTrait
 {
@@ -18,9 +17,8 @@ trait BootableApplicationTrait
      */
     public static function boot(ServicesProviderInterface ...$servicesProviders): self
     {
-        /** @psalm-suppress ArgumentTypeCoercion */
         $container = self::buildContainer(
-            concat(
+            ...concat(
                 self::getObligatoryServiceProviders(),
                 $servicesProviders
             )
@@ -37,18 +35,12 @@ trait BootableApplicationTrait
         return [];
     }
 
-    /**
-     * @param list<ServicesProviderInterface> $servicesProviders
-     */
-    private static function buildContainer(array $servicesProviders): ContainerInterface
+    private static function buildContainer(ServicesProviderInterface ...$servicesProviders): ContainerInterface
     {
         $containerBuilder = new ContainerBuilder();
-        map(
-            $servicesProviders,
-            function (ServicesProviderInterface $serviceProvider) use ($containerBuilder): void {
-                $containerBuilder->registerServicesProvider($serviceProvider);
-            }
-        );
+        foreach ($servicesProviders as $servicesProvider) {
+            $containerBuilder->registerServicesProvider($servicesProvider);
+        }
 
         return $containerBuilder->build();
     }

--- a/src/Http/WebApplication.php
+++ b/src/Http/WebApplication.php
@@ -14,6 +14,7 @@ use Noctis\KickStart\Http\Routing\Router\RouterInterface;
 use Noctis\KickStart\Http\Routing\RoutesCollection;
 use Noctis\KickStart\Http\Service\RequestDecoratorInterface;
 use Noctis\KickStart\Provider\HttpServicesProvider;
+use Noctis\KickStart\Provider\ServicesProviderInterface;
 use Noctis\KickStart\Provider\StandardServicesProvider;
 use Noctis\KickStart\Provider\TwigServiceProvider;
 use Noctis\KickStart\RunnableInterface;
@@ -27,6 +28,7 @@ final class WebApplication implements RunnableInterface
 
     /**
      * @inheritDoc
+     * @psalm-return list<ServicesProviderInterface>
      */
     protected static function getObligatoryServiceProviders(): array
     {


### PR DESCRIPTION
That annotation in `WebApplication` needs to be there, at least for know. For some reason, Psalm does not follow the `@inheritDoc` annotation there to `BootrableTrait` and thinks the method returns `array<key, mixed>` :(