### PR TITLE
Support for Defining Console Commands Names in Class Attributes

### DIFF
--- a/src/Console/Service/CommandNameExtractor.php
+++ b/src/Console/Service/CommandNameExtractor.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Console\Service;
+
+use ReflectionClass;
+use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+final class CommandNameExtractor implements CommandNameExtractorInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function extract(string $commandClassName): string
+    {
+        $reflection = new ReflectionClass($commandClassName);
+        $name = $this->getNameFromAttributes($reflection);
+        if ($name !== null) {
+            return $name;
+        }
+
+        $name = $this->getNameFromProperty($reflection);
+        if ($name !== null) {
+            return $name;
+        }
+
+        throw new RuntimeException(
+            sprintf(
+                'Could not determine command name from class "%s".',
+                $commandClassName
+            )
+        );
+    }
+
+    private function getNameFromAttributes(ReflectionClass $reflection): ?string
+    {
+        $attributes = $reflection->getAttributes(AsCommand::class);
+        if ($attributes === []) {
+            return null;
+        }
+
+        return $attributes[0]->getArguments()['name'] ?? null;
+    }
+
+    private function getNameFromProperty(ReflectionClass $reflection): ?string
+    {
+        try {
+            return $reflection->getProperty('defaultName')
+                ->getValue();
+        } catch (\ReflectionException $ex) {
+            return null;
+        }
+    }
+}

--- a/src/Console/Service/CommandNameExtractor.php
+++ b/src/Console/Service/CommandNameExtractor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Noctis\KickStart\Console\Service;
 
 use ReflectionClass;
+use ReflectionException;
 use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -41,15 +42,17 @@ final class CommandNameExtractor implements CommandNameExtractorInterface
             return null;
         }
 
+        /** @var string|null */
         return $attributes[0]->getArguments()['name'] ?? null;
     }
 
     private function getNameFromProperty(ReflectionClass $reflection): ?string
     {
         try {
+            /** @var string|null */
             return $reflection->getProperty('defaultName')
                 ->getValue();
-        } catch (\ReflectionException $ex) {
+        } catch (ReflectionException $ex) {
             return null;
         }
     }

--- a/src/Console/Service/CommandNameExtractorInterface.php
+++ b/src/Console/Service/CommandNameExtractorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Console\Service;
+
+use Noctis\KickStart\Console\Command\AbstractCommand;
+
+interface CommandNameExtractorInterface
+{
+    /**
+     * @param class-string<AbstractCommand> $commandClassName
+     */
+    public function extract(string $commandClassName): string;
+}

--- a/src/Provider/ConsoleServicesProvider.php
+++ b/src/Provider/ConsoleServicesProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Provider;
+
+use Noctis\KickStart\Console\Service\CommandNameExtractor;
+use Noctis\KickStart\Console\Service\CommandNameExtractorInterface;
+
+final class ConsoleServicesProvider implements ServicesProviderInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function getServicesDefinitions(): array
+    {
+        return [
+            CommandNameExtractorInterface::class => CommandNameExtractor::class,
+        ];
+    }
+}

--- a/tests/unit/Console/Service/CommandNameExtractor/ExtractTests.php
+++ b/tests/unit/Console/Service/CommandNameExtractor/ExtractTests.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Console\Service\CommandNameExtractor;
+
+use Noctis\KickStart\Console\Service\CommandNameExtractor;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+final class ExtractTests extends TestCase
+{
+    public function test_name_from_attribute_is_used_if_attribute_is_defined(): void
+    {
+        $expectedResult = 'attribute:named';
+        $nameExtractor = new CommandNameExtractor();
+
+        $result = $nameExtractor->extract(CommandWithNameAttribute::class);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function test_name_from_attribute_takes_precedence_over_name_in_property(): void
+    {
+        $expectedResult = 'attribute:first';
+        $nameExtractor = new CommandNameExtractor();
+
+        $result = $nameExtractor->extract(CommandWithNamePropertyAndNameAttribute::class);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    public function test_name_from_property_is_used_if_the_attribute_is_missing(): void
+    {
+        $expectedResult = 'property:named';
+        $nameExtractor = new CommandNameExtractor();
+
+        $result = $nameExtractor->extract(CommandWithNameProperty::class);
+
+        $this->assertSame($expectedResult, $result);
+    }
+}
+
+final class CommandWithNameProperty
+{
+    protected static $defaultName = 'property:named';
+}
+
+#[AsCommand(name: 'attribute:named')]
+final class CommandWithNameAttribute
+{
+}
+
+#[AsCommand(name: 'attribute:first')]
+final class CommandWithNamePropertyAndNameAttribute
+{
+    protected static $defaultName = 'property:second';
+}


### PR DESCRIPTION
Naming CLI commands in class properties (`$defaultName`) has been marked as deprecated in Symfony 6.1-BETA1 (see: https://github.com/symfony/symfony/pull/45361).

All the cool kids now name their commands _via_ class attributes :)

See: https://github.com/Noctis/kickstart-app/pull/106