### PR TITLE
Changes to Generating Paths from Named Routes

### DIFF
--- a/src/Exception/RouteNotFoundException.php
+++ b/src/Exception/RouteNotFoundException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noctis\KickStart\Exception;
+
+use InvalidArgumentException;
+
+use function Psl\Str\format;
+
+final class RouteNotFoundException extends InvalidArgumentException
+{
+    public function __construct(string $name)
+    {
+        parent::__construct(
+            format('Could not find route with given name: "%s".', $name)
+        );
+    }
+}

--- a/src/Service/PathGenerator.php
+++ b/src/Service/PathGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Noctis\KickStart\Service;
 
+use Noctis\KickStart\Exception\RouteNotFoundException;
 use Noctis\KickStart\Http\Routing\RoutesCollection;
 use Noctis\KickStart\Http\Routing\RoutesCollectionInterface;
 use Noctis\KickStart\ValueObject\GeneratedUriInterface;
@@ -33,11 +34,14 @@ final class PathGenerator implements PathGeneratorInterface
         /** @psalm-suppress PossiblyNullReference */
         $route = $this->routes
             ->getNamedRoute($routeName);
-        $path = $route !== null
-            ? $route->getPath()
-            : $routeName;
+        if ($route === null) {
+            throw new RouteNotFoundException($routeName);
+        }
 
         return $this->urlGenerator
-            ->generate($path, $params);
+            ->generate(
+                $route->getPath(),
+                $params
+            );
     }
 }

--- a/src/Service/PathGeneratorInterface.php
+++ b/src/Service/PathGeneratorInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Noctis\KickStart\Service;
 
+use Noctis\KickStart\Exception\RouteNotFoundException;
 use Noctis\KickStart\Http\Routing\RoutesCollectionInterface;
 use Noctis\KickStart\ValueObject\GeneratedUriInterface;
 
@@ -13,6 +14,8 @@ interface PathGeneratorInterface
 
     /**
      * @param array<string, string|int> $params
+     *
+     * @throws RouteNotFoundException
      */
     public function toRoute(string $routeName, array $params = []): GeneratedUriInterface;
 }

--- a/src/Service/Twig/Extension/UrlExtension.php
+++ b/src/Service/Twig/Extension/UrlExtension.php
@@ -15,12 +15,12 @@ final class UrlExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction(
-                'path',
-                $this->getPath(...)
+                'route',
+                $this->getRoute(...)
             ),
         ];
     }
@@ -28,7 +28,7 @@ final class UrlExtension extends AbstractExtension
     /**
      * @param array<string, string|int> $params
      */
-    private function getPath(string $routeName, array $params = []): string
+    private function getRoute(string $routeName, array $params = []): string
     {
         return $this->pathGenerator
             ->toRoute($routeName, $params)

--- a/tests/acceptance/Service/PathGenerator/ToRouteTests.php
+++ b/tests/acceptance/Service/PathGenerator/ToRouteTests.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Acceptance\Service\PathGenerator;
 
+use Noctis\KickStart\Exception\RouteNotFoundException;
 use Noctis\KickStart\Http\Routing\Route;
 use Noctis\KickStart\Http\Routing\RoutesCollection;
 use Noctis\KickStart\Http\Routing\RoutesCollectionInterface;
@@ -14,22 +15,21 @@ use PHPUnit\Framework\TestCase;
 
 final class ToRouteTests extends TestCase
 {
-    public function test_it_returns_given_route_name_with_params_as_query_string_if_no_routes_were_provided(): void
+    public function test_it_throws_an_exception_if_no_routes_were_provided(): void
     {
+        $this->expectException(RouteNotFoundException::class);
+
         $generator = new PathGenerator(
             $this->getUrlGenerator()
         );
 
-        $path = $generator->toRoute('sign-in', ['foo' => 'bar']);
-
-        $this->assertSame(
-            'sign-in?foo=bar',
-            $path->toString()
-        );
+        $generator->toRoute('sign-in', ['foo' => 'bar']);
     }
 
-    public function test_it_returns_given_route_name_with_params_as_query_string_if_no_matching_route_exists(): void
+    public function test_it_throws_an_exception_if_no_matching_route_exists(): void
     {
+        $this->expectException(RouteNotFoundException::class);
+
         $generator = new PathGenerator(
             $this->getUrlGenerator()
         );
@@ -37,12 +37,7 @@ final class ToRouteTests extends TestCase
             $this->getRoutes(['home' => '/'])
         );
 
-        $path = $generator->toRoute('sign-in', ['foo' => 'bar']);
-
-        $this->assertSame(
-            'sign-in?foo=bar',
-            $path->toString()
-        );
+        $generator->toRoute('sign-in', ['foo' => 'bar']);
     }
 
     public function test_it_returns_route_based_path_if_matching_route_exists(): void


### PR DESCRIPTION
After long consideration I've decided that:

a) referencing unknown routes in views, due to a typo or whatever, should be considered an critical error and fail "loudly" (exception), and
b) `route()` will be a better name for Twig's `path()` function.

And so:

* an exception will be thrown when trying to generate a path using a unknown route name,
* Twig's `path()` function has been renamed to `route()`.

See: https://github.com/Noctis/kickstart-app/pull/111