### PR TITLE
More liberal `autowire()` DI builder helper's methods

### DIFF
--- a/src/Service/Container/Definition/AutowireDefinitionInterface.php
+++ b/src/Service/Container/Definition/AutowireDefinitionInterface.php
@@ -4,17 +4,9 @@ declare(strict_types=1);
 
 namespace Noctis\KickStart\Service\Container\Definition;
 
-use Closure;
-
 interface AutowireDefinitionInterface extends ContainerDefinitionInterface
 {
-    public function constructorParameter(
-        string $name,
-        string | int | float | bool | array | Closure | ContainerDefinitionInterface $value
-    ): self;
+    public function constructorParameter(string $name, mixed $value): self;
 
-    public function method(
-        string $methodName,
-        string | int | float | bool | array | Closure | ContainerDefinitionInterface $value
-    ): self;
+    public function method(string $methodName, mixed ...$values): self;
 }


### PR DESCRIPTION
Made the following changes to Kickstart's `autowire()` DI builder helper methods:

* the `constructorParameter()` method's `$value` parameter can now be of any value (`mixed`),
* the `method()` method now accepts variable number of values (`$value` parameter), of any kind (`mixed`).

This makes those two methods roughly the same as their PHP-DI's equivalents.